### PR TITLE
feat: Add helper methods for easier metafields access

### DIFF
--- a/Sources/CosmicSDK/Model.swift
+++ b/Sources/CosmicSDK/Model.swift
@@ -267,6 +267,26 @@ struct Command: Codable {
     public let metadata: [String: AnyCodable]?
 }
 
+// MARK: - Object Extensions
+extension Object {
+    /// Access metafield by key for easier usage
+    public func metafieldValue(for key: String) -> AnyCodable? {
+        return metafields?.first(where: { $0.key == key })?.value
+    }
+    
+    /// Get all metafields as a dictionary for convenience
+    public var metafieldsDict: [String: AnyCodable]? {
+        guard let metafields = metafields else { return nil }
+        var dict: [String: AnyCodable] = [:]
+        for field in metafields {
+            if let value = field.value {
+                dict[field.key] = value
+            }
+        }
+        return dict.isEmpty ? nil : dict
+    }
+}
+
 // MARK: - Media Models
 public struct CosmicMedia: Codable {
     public let id: String

--- a/Tests/CosmicSDKTests/MetafieldsHelperTests.swift
+++ b/Tests/CosmicSDKTests/MetafieldsHelperTests.swift
@@ -1,0 +1,134 @@
+//
+//  MetafieldsHelperTests.swift
+//
+//
+//  Created to test metafields helper methods
+//
+
+import XCTest
+@testable import CosmicSDK
+
+final class MetafieldsHelperTests: XCTestCase {
+    
+    func testMetafieldValueHelper() throws {
+        let json = """
+        {
+            "title": "Test Object",
+            "metafields": [
+                {
+                    "type": "text",
+                    "title": "Name",
+                    "key": "name",
+                    "value": "John Doe"
+                },
+                {
+                    "type": "text",
+                    "title": "Username",
+                    "key": "username",
+                    "value": "johndoe"
+                },
+                {
+                    "type": "text",
+                    "title": "Image URL",
+                    "key": "image_url",
+                    "value": "https://example.com/image.jpg"
+                }
+            ]
+        }
+        """
+        
+        let data = json.data(using: .utf8)!
+        let object = try JSONDecoder().decode(Object.self, from: data)
+        
+        // Test metafieldValue(for:) method
+        let nameValue = object.metafieldValue(for: "name")
+        XCTAssertNotNil(nameValue)
+        XCTAssertEqual(nameValue?.value as? String, "John Doe")
+        
+        let usernameValue = object.metafieldValue(for: "username")
+        XCTAssertNotNil(usernameValue)
+        XCTAssertEqual(usernameValue?.value as? String, "johndoe")
+        
+        let imageUrlValue = object.metafieldValue(for: "image_url")
+        XCTAssertNotNil(imageUrlValue)
+        XCTAssertEqual(imageUrlValue?.value as? String, "https://example.com/image.jpg")
+        
+        // Test non-existent key
+        let nonExistent = object.metafieldValue(for: "non_existent")
+        XCTAssertNil(nonExistent)
+    }
+    
+    func testMetafieldsDictHelper() throws {
+        let json = """
+        {
+            "title": "Test Object",
+            "metafields": [
+                {
+                    "type": "text",
+                    "title": "Name",
+                    "key": "name",
+                    "value": "John Doe"
+                },
+                {
+                    "type": "text",
+                    "title": "Username",
+                    "key": "username",
+                    "value": "johndoe"
+                },
+                {
+                    "type": "objects",
+                    "title": "Shows",
+                    "key": "shows",
+                    "value": ["show1", "show2", "show3"]
+                }
+            ]
+        }
+        """
+        
+        let data = json.data(using: .utf8)!
+        let object = try JSONDecoder().decode(Object.self, from: data)
+        
+        // Test metafieldsDict property
+        let dict = object.metafieldsDict
+        XCTAssertNotNil(dict)
+        XCTAssertEqual(dict?.count, 3)
+        XCTAssertEqual(dict?["name"]?.value as? String, "John Doe")
+        XCTAssertEqual(dict?["username"]?.value as? String, "johndoe")
+        XCTAssertEqual((dict?["shows"]?.value as? [String])?.count, 3)
+    }
+    
+    func testEmptyMetafields() throws {
+        let json = """
+        {
+            "title": "Test Object",
+            "metafields": []
+        }
+        """
+        
+        let data = json.data(using: .utf8)!
+        let object = try JSONDecoder().decode(Object.self, from: data)
+        
+        let value = object.metafieldValue(for: "any_key")
+        XCTAssertNil(value)
+        
+        let dict = object.metafieldsDict
+        XCTAssertNil(dict)
+    }
+    
+    func testNilMetafields() throws {
+        let json = """
+        {
+            "title": "Test Object"
+        }
+        """
+        
+        let data = json.data(using: .utf8)!
+        let object = try JSONDecoder().decode(Object.self, from: data)
+        
+        let value = object.metafieldValue(for: "any_key")
+        XCTAssertNil(value)
+        
+        let dict = object.metafieldsDict
+        XCTAssertNil(dict)
+    }
+}


### PR DESCRIPTION
- Add metafieldValue(for:) method to access individual metafields by key
- Add metafieldsDict computed property to get all metafields as a dictionary
- Add comprehensive tests for the new helper methods
- Provides convenient access patterns while maintaining type safety