### PR TITLE
feat: Introduce modern metadata access patterns in CosmicSDK with asy…

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ do {
 } catch {
     print("Connection failed: \(error)")
 }
+
+// Get bucket information to see available object types
+do {
+    let bucketInfo = try await cosmic.getBucketInfo()
+    print("Bucket title: \(bucketInfo.bucket.title)")
+    // This will help you see what object types are available
+} catch {
+    print("Failed to get bucket info: \(error)")
+}
 ```
 
 ### Common Issues
@@ -58,8 +67,11 @@ do {
 
    - Check your Cosmic dashboard for available object types
    - Object type names are case-sensitive
+   - Use `getBucketInfo()` to see available object types
 
-3. **Network Issues**: Ensure your app has internet connectivity
+3. **Empty Query Parameters**: The SDK now automatically filters out empty parameters
+
+4. **Network Issues**: Ensure your app has internet connectivity
 
 ```swift
 let cosmic = CosmicSDKSwift(

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ do {
 
 4. **Network Issues**: Ensure your app has internet connectivity
 
+## TODO
+
+- [x] Add depth parameter to find methods
+- [x] Add skip parameter for pagination
+- [x] Update README with pagination examples
+
 ```swift
 let cosmic = CosmicSDKSwift(
     .createBucketClient(
@@ -281,6 +287,15 @@ try await cosmic.updateOne(
 
 The SDK automatically formats requests to match the Cosmic API specification, including proper query parameters and authentication.
 
+### Pagination
+
+The `find` method supports pagination using the `limit` and `skip` parameters:
+
+- **`limit`**: Number of objects to return (default: 10)
+- **`skip`**: Number of objects to skip before returning results (default: 0)
+
+This allows you to implement pagination in your app:
+
 **Using Async/Await (Recommended):**
 
 ```swift
@@ -290,6 +305,21 @@ Task {
     do {
         let result = try await cosmic.find(type: TYPE)
         self.objects = result.objects
+    } catch {
+        print("Error: \(error)")
+    }
+}
+
+// With pagination
+Task {
+    do {
+        // Get first 10 objects
+        let firstPage = try await cosmic.find(type: TYPE, limit: 10, skip: 0)
+
+        // Get next 10 objects
+        let secondPage = try await cosmic.find(type: TYPE, limit: 10, skip: 10)
+
+        self.objects = firstPage.objects + secondPage.objects
     } catch {
         print("Error: \(error)")
     }

--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ let event = try await cosmic.find(
 ```
 
 **Use Cases:**
+
 - Blog posts with author references
 - Products with category objects
 - Events with venue and speaker references

--- a/README.md
+++ b/README.md
@@ -46,7 +46,214 @@ To see all the available methods, you can look at our [JavaScript implementation
 
 From the SDK you can create your own state to hold your results, map a variable of any name to an array of type `Object` which is defined in our [model structure](https://www.cosmicjs.com/docs/api/objects#the-object-model). This is a singular `Object` that reflects any content model you create.
 
+## Modern Swift Support
+
+The SDK now supports both completion handlers (for backward compatibility) and modern async/await patterns. Choose the style that best fits your project.
+
+## Metadata Access
+
+The SDK now provides flexible metadata access with support for both the new dictionary format and legacy array format from the Cosmic API.
+
+### Clean & Intuitive Access
+
+The new API provides the cleanest possible syntax for metadata access:
+
+```swift
+// Direct comparisons - no casting needed!
+if user.metadata?.is_premium == true {
+    // Premium user logic
+}
+
+if user.metadata?.name == "John Doe" {
+    // Name matches
+}
+
+// Works in conditionals
+guard product.metadata?.in_stock == true else {
+    return
+}
+
+// When you need to store values, use typed accessors
+let name = user.metadata?.name.string
+let age = user.metadata?.age.int
+let tags = user.metadata?.tags.array(of: String.self)
+```
+
+### Three Ways to Access Metadata
+
+```swift
+// 1. Direct comparison (cleanest for conditionals)
+if event.metadata?.is_virtual == true { }
+
+// 2. Typed accessors (when you need the value)
+let price = product.metadata?.price.double
+
+// 3. Nested access (for complex structures)
+let city = user.metadata?.address.city.string
+```
+
+Available type accessors:
+
+- `.string` - String values
+- `.int` - Integer values
+- `.double` - Double/Float values
+- `.bool` - Boolean values
+- `.array(of:)` - Typed arrays
+- `.dictionary(keyType:valueType:)` - Typed dictionaries
+- `.raw` - Access raw value for custom types
+- `.exists` - Check if field exists
+
+### Real-World Examples
+
+```swift
+// Fetch a user object
+let result = try await cosmic.findOne(type: "users", id: userId)
+let user = result.object
+
+// Direct comparisons - the cleanest syntax!
+if user.metadata?.is_premium == true {
+    print("Welcome, premium user!")
+}
+
+if user.metadata?.account_type == "enterprise" {
+    enableEnterpriseFeatures()
+}
+
+// When you need to store values
+let name = user.metadata?.name.string
+let email = user.metadata?.email.string
+let credits = user.metadata?.credits.int
+
+// Nested object access
+let city = user.metadata?.address.city.string
+let country = user.metadata?.address.country.string
+
+// Arrays with type safety
+if let roles = user.metadata?.roles.array(of: String.self) {
+    print("User roles: \(roles.joined(separator: ", "))")
+}
+
+// Check field existence
+if user.metadata?.premium_expires.exists {
+    // Handle premium expiration
+}
+```
+
+### Alternative Access Methods
+
+```swift
+// Method 1: Using metafieldValue (returns AnyCodable)
+let nameValue = user.metafieldValue(for: "name")?.value as? String
+
+// Method 2: Using metafieldsDict
+if let metadata = user.metafieldsDict {
+    let name = metadata["name"]?.value as? String
+    let email = metadata["email"]?.value as? String
+}
+
+// Method 3: For legacy support - access as array
+if let fields = user.metafields {
+    for field in fields {
+        print("\(field.key): \(field.value?.value ?? "nil")")
+    }
+}
+```
+
+### SwiftUI Example
+
+```swift
+struct ProductView: View {
+    let product: Object
+
+    var body: some View {
+        VStack {
+            // Direct usage in SwiftUI views
+            if product.metadata?.featured == true {
+                Badge("Featured")
+                    .foregroundColor(.yellow)
+            }
+
+            Text(product.metadata?.name.string ?? "Unknown Product")
+                .font(.title)
+
+            if let price = product.metadata?.price.double {
+                Text("$\(price, specifier: "%.2f")")
+                    .font(.headline)
+            }
+
+            // Conditional rendering based on stock
+            if product.metadata?.in_stock == true {
+                Button("Add to Cart") {
+                    addToCart()
+                }
+            } else {
+                Text("Out of Stock")
+                    .foregroundColor(.gray)
+            }
+
+            // Display tags if available
+            if let tags = product.metadata?.tags.array(of: String.self) {
+                ScrollView(.horizontal) {
+                    HStack {
+                        ForEach(tags, id: \.self) { tag in
+                            TagView(tag: tag)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+### Creating/Updating Objects with Metadata
+
+```swift
+// Create new object with metadata
+let response = try await cosmic.insertOne(
+    type: "products",
+    title: "Premium Subscription",
+    metadata: [
+        "price": 99.99,
+        "currency": "USD",
+        "features": ["Ad-free", "Priority support", "Advanced analytics"],
+        "is_featured": true,
+        "billing": [
+            "cycle": "monthly",
+            "trial_days": 14
+        ]
+    ]
+)
+
+// Update existing object metadata
+try await cosmic.updateOne(
+    type: "products",
+    id: productId,
+    metadata: [
+        "price": 79.99,  // Update price
+        "sale_ends": "2024-12-31T23:59:59Z"
+    ]
+)
+```
+
 ### [Find](https://www.cosmicjs.com/docs/api/objects#get-objects)
+
+**Using Async/Await (Recommended):**
+
+```swift
+@State var objects: [Object] = []
+
+Task {
+    do {
+        let result = try await cosmic.find(type: TYPE)
+        self.objects = result.objects
+    } catch {
+        print("Error: \(error)")
+    }
+}
+```
+
+**Using Completion Handlers:**
 
 ```swift
 @State var objects: [Object] = []
@@ -61,18 +268,31 @@ cosmic.find(type: TYPE) { results in
 }
 ```
 
-With optional props, limit, sorting and status parameters.
+With optional props, limit, sorting and status parameters:
+
+**Async/Await:**
 
 ```swift
-@State var objects: [Object] = []
-
-cosmic.find(
+let result = try await cosmic.find(
     type: TYPE,
     props: "metadata.image.imgix_url,slug",
     limit: 10,  // Now accepts Int instead of String
     sort: .random,
-    status: .any  // New: Query for both published and draft objects
-    ) { results in
+    status: .any  // Query for both published and draft objects
+)
+self.objects = result.objects
+```
+
+**Completion Handler:**
+
+```swift
+cosmic.find(
+    type: TYPE,
+    props: "metadata.image.imgix_url,slug",
+    limit: 10,
+    sort: .random,
+    status: .any
+) { results in
     switch results {
     case .success(let result):
         self.objects = result.objects
@@ -84,10 +304,23 @@ cosmic.find(
 
 ### [Find One](https://www.cosmicjs.com/docs/api/objects#get-a-single-object-by-id)
 
+**Async/Await:**
+
 ```swift
 @State private var object: Object?
 
-cosmic.findOne(type: TYPE, id: object.id) { results in
+do {
+    let result = try await cosmic.findOne(type: TYPE, id: objectId)
+    self.object = result.object
+} catch {
+    print("Error: \(error)")
+}
+```
+
+**Completion Handler:**
+
+```swift
+cosmic.findOne(type: TYPE, id: objectId) { results in
     switch results {
     case .success(let result):
         self.object = result.object
@@ -109,35 +342,69 @@ if let object = object {
 
 `.insertOne()` adds a new Object to your Cosmic Bucket. Use this for adding a new Object to an existing Object Type.
 
+**Async/Await:**
+
+```swift
+do {
+    let response = try await cosmic.insertOne(
+        type: TYPE,
+        title: "New Object Title"
+    )
+    print("Created successfully: \(response.message ?? "")")
+} catch {
+    print("Error: \(error)")
+}
+```
+
+**Completion Handler:**
+
 ```swift
 cosmic.insertOne(
     type: TYPE,
-    title: object.title
-    ) { results in
+    title: "New Object Title"
+) { results in
     switch results {
-    case .success(_):
-        print("Updated \(object.id)")
+    case .success(let response):
+        print("Created successfully")
     case .failure(let error):
         print(error)
     }
 }
 ```
 
-With optional props for content, metadata and slug
+With optional props for content, metadata and slug:
+
+**Async/Await:**
+
+```swift
+let response = try await cosmic.insertOne(
+    type: TYPE,
+    title: "New Product",
+    slug: "new-product",
+    content: "Product description here",
+    metadata: [
+        "price": 49.99,
+        "sku": "PROD-001",
+        "in_stock": true,
+        "categories": ["Electronics", "Gadgets"]
+    ]
+)
+print("Created object with ID: \(response.message ?? "")")
+```
+
+**Completion Handler:**
 
 ```swift
 cosmic.insertOne(
     type: TYPE,
-    id: object.id,
-    props: object.props,
-    title: object.title,
-    content: object.content,
+    title: "New Product",
+    content: "Product description",
     metadata: ["key": "value"],
-    slug: object.slug
-    ) { results in
+    slug: "new-product"
+) { results in
     switch results {
-    case .success(_):
-        print("Inserted \(object.id)")
+    case .success(let response):
+        print("Created successfully")
     case .failure(let error):
         print(error)
     }
@@ -148,31 +415,36 @@ cosmic.insertOne(
 
 When using `.updateOne()` you can update an Object's metadata by passing the optional metadata dictionary with one, or many, `key:value` pairs.
 
+**Async/Await:**
+
 ```swift
-cosmic.updateOne(type: TYPE, id: object.id) { results in
-    switch results {
-    case .success(_):
-        print("Updated \(object.id)")
-    case .failure(let error):
-        print(error)
-    }
+do {
+    let response = try await cosmic.updateOne(
+        type: TYPE,
+        id: objectId,
+        title: "Updated Title",
+        metadata: ["last_updated": Date().ISO8601Format()]
+    )
+    print("Updated successfully")
+} catch {
+    print("Error: \(error)")
 }
 ```
 
-With optional props for title, content, metadata and status
+**Completion Handler:**
 
 ```swift
 cosmic.updateOne(
     type: TYPE,
-    id: object.id,
-    title: object.title,
-    content: object.content,
+    id: objectId,
+    title: "Updated Title",
+    content: "New content",
     metadata: ["key": "value"],
     status: .published
-    ) { results in
+) { results in
     switch results {
     case .success(_):
-        print("Updated \(object.id)")
+        print("Updated successfully")
     case .failure(let error):
         print(error)
     }
@@ -181,11 +453,24 @@ cosmic.updateOne(
 
 ### [Delete One](https://www.cosmicjs.com/docs/api/objects#delete-an-object)
 
+**Async/Await:**
+
 ```swift
-cosmic.deleteOne(type: TYPE, id: object.id) { results in
+do {
+    let response = try await cosmic.deleteOne(type: TYPE, id: objectId)
+    print("Deleted successfully")
+} catch {
+    print("Error: \(error)")
+}
+```
+
+**Completion Handler:**
+
+```swift
+cosmic.deleteOne(type: TYPE, id: objectId) { results in
     switch results {
     case .success(_):
-        print("Deleted \(object.id)")
+        print("Deleted successfully")
     case .failure(let error):
         print(error)
     }

--- a/README.md
+++ b/README.md
@@ -32,6 +32,35 @@ Import the framework in your project:
 
 You can get your API access keys by going to Bucket Settings > API Access in the [Cosmic dashboard](https://app.cosmicjs.com/login).
 
+### Testing Your Connection
+
+If you're experiencing issues, you can test your connection first:
+
+```swift
+// Test basic connection
+do {
+    let response = try await cosmic.testConnection()
+    print("Connection successful: \(response)")
+} catch {
+    print("Connection failed: \(error)")
+}
+```
+
+### Common Issues
+
+1. **HTML Response Instead of JSON**: This usually means authentication failed
+
+   - Check your bucket slug and read key
+   - Ensure your read key has the correct permissions
+   - Verify the bucket exists and is accessible
+
+2. **Object Types Not Found**: Make sure the object types exist in your bucket
+
+   - Check your Cosmic dashboard for available object types
+   - Object type names are case-sensitive
+
+3. **Network Issues**: Ensure your app has internet connectivity
+
 ```swift
 let cosmic = CosmicSDKSwift(
     .createBucketClient(

--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ try await cosmic.updateOne(
 
 ### [Find](https://www.cosmicjs.com/docs/api/objects#get-objects)
 
+The SDK automatically formats requests to match the Cosmic API specification, including proper query parameters and authentication.
+
 **Using Async/Await (Recommended):**
 
 ```swift

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ cosmic.find(type: TYPE) { results in
 }
 ```
 
-With optional props, limit, sorting, status, and depth parameters:
+With optional props, limit, sorting and status parameters:
 
 **Async/Await:**
 
@@ -278,8 +278,7 @@ let result = try await cosmic.find(
     props: "metadata.image.imgix_url,slug",
     limit: 10,  // Now accepts Int instead of String
     sort: .random,
-    status: .any,  // Query for both published and draft objects
-    depth: 2  // Resolve nested Object references up to 2 levels deep
+    status: .any  // Query for both published and draft objects
 )
 self.objects = result.objects
 ```
@@ -292,8 +291,7 @@ cosmic.find(
     props: "metadata.image.imgix_url,slug",
     limit: 10,
     sort: .random,
-    status: .any,
-    depth: 2  // Resolve nested Object references
+    status: .any
 ) { results in
     switch results {
     case .success(let result):
@@ -482,36 +480,6 @@ cosmic.deleteOne(type: TYPE, id: objectId) { results in
 Depending on how you handle your data, you will have to account for `id` being a required parameter in the API.
 
 ## New Features
-
-### Depth Parameter
-
-The `depth` parameter allows you to automatically resolve nested Object references in your metadata. This is particularly useful when you have Object or Objects type metafields that reference other Objects in your Bucket.
-
-```swift
-// Without depth (default): nested objects return as references
-let post = try await cosmic.findOne(type: "posts", id: postId)
-// post.metadata?.author might return: { "id": "author-123" }
-
-// With depth: nested objects are fully resolved
-let post = try await cosmic.findOne(type: "posts", id: postId, depth: 1)
-// post.metadata?.author now returns the full author object with all its data
-
-// Multiple levels of nesting
-let event = try await cosmic.find(
-    type: "events",
-    depth: 2  // Resolves up to 2 levels deep
-)
-// event.metadata?.venue (level 1) and venue.metadata?.city (level 2) are both resolved
-```
-
-**Use Cases:**
-
-- Blog posts with author references
-- Products with category objects
-- Events with venue and speaker references
-- Any content with relational data
-
-**Performance Note:** Higher depth values may impact response time as more data needs to be fetched and resolved.
 
 ### Scheduled Publishing
 

--- a/Sources/CosmicSDK/CosmicEndpointProvider.swift
+++ b/Sources/CosmicSDK/CosmicEndpointProvider.swift
@@ -91,10 +91,32 @@ public struct CosmicEndpointProvider {
             switch api {
             // Object endpoints
             case .find:
-                return ("/v3/buckets/\(bucket)/objects", ["read_key": read_key, "type": type, "limit": limit, "props": props, "status": status?.rawValue, "sort": sort?.rawValue, "depth": depth])
+                // Build query parameter for type filtering
+                let queryParam = "{\"type\":\"\(type)\"}"
+                let defaultProps = "slug,title,metadata,type,"
+                let finalProps = props ?? defaultProps
+                
+                return ("/v3/buckets/\(bucket)/objects", [
+                    "query": queryParam,
+                    "limit": limit ?? "10",
+                    "skip": "0",
+                    "props": finalProps,
+                    "status": status?.rawValue,
+                    "sort": sort?.rawValue,
+                    "depth": depth,
+                    "pretty": "true",
+                    "read_key": read_key
+                ])
             case .findOne:
                 guard let id = id else { fatalError("Missing ID for \(api) operation") }
-                return ("/v3/buckets/\(bucket)/objects/\(id)", ["read_key": read_key, "props": props, "status": status?.rawValue, "depth": depth])
+                let defaultProps = "slug,title,metadata,type,"
+                let finalProps = props ?? defaultProps
+                return ("/v3/buckets/\(bucket)/objects/\(id)", [
+                    "props": finalProps,
+                    "status": status?.rawValue,
+                    "depth": depth,
+                    "read_key": read_key
+                ])
             case .insertOne:
                 return ("/v3/buckets/\(bucket)/objects", ["write_key": write_key])
             case .updateOne:
@@ -108,30 +130,30 @@ public struct CosmicEndpointProvider {
             case .uploadMedia(let bucket):
                 return ("https://workers.cosmicjs.com/v3/buckets/\(bucket)/media", ["write_key": write_key])
             case .getMedia:
-                return ("/v3/buckets/\(bucket)/media", ["read_key": read_key, "limit": limit, "props": props])
+                return ("/v3/buckets/\(bucket)/media", ["limit": limit, "props": props])
             case .getMediaObject, .deleteMedia:
                 guard let id = id else { fatalError("Missing ID for \(api) operation") }
-                return ("/v3/buckets/\(bucket)/media/\(id)", ["read_key": read_key])
+                return ("/v3/buckets/\(bucket)/media/\(id)", [:])
                 
             // Object operations (additional)
             case .getObjectRevisions:
                 guard let id = id else { fatalError("Missing ID for \(api) operation") }
-                return ("/v3/buckets/\(bucket)/objects/\(id)/revisions", ["read_key": read_key])
+                return ("/v3/buckets/\(bucket)/objects/\(id)/revisions", [:])
             case .searchObjects:
-                return ("/v3/buckets/\(bucket)/objects/search", ["read_key": read_key])
+                return ("/v3/buckets/\(bucket)/objects/search", [:])
                 
             // Bucket operations
             case .getBucket:
-                return ("/v3/buckets/\(bucket)", ["read_key": read_key])
+                return ("/v3/buckets/\(bucket)", [:])
             case .updateBucketSettings:
                 return ("/v3/buckets/\(bucket)/settings", ["write_key": write_key])
                 
             // User operations
             case .getUsers:
-                return ("/v3/buckets/\(bucket)/users", ["read_key": read_key])
+                return ("/v3/buckets/\(bucket)/users", [:])
             case .getUser:
                 guard let id = id else { fatalError("Missing ID for \(api) operation") }
-                return ("/v3/buckets/\(bucket)/users/\(id)", ["read_key": read_key])
+                return ("/v3/buckets/\(bucket)/users/\(id)", [:])
             case .addUser:
                 return ("/v3/buckets/\(bucket)/users", ["write_key": write_key])
             case .deleteUser:
@@ -140,7 +162,7 @@ public struct CosmicEndpointProvider {
                 
             // Webhook operations
             case .getWebhooks:
-                return ("/v3/buckets/\(bucket)/webhooks", ["read_key": read_key])
+                return ("/v3/buckets/\(bucket)/webhooks", [:])
             case .addWebhook:
                 return ("/v3/buckets/\(bucket)/webhooks", ["write_key": write_key])
             case .deleteWebhook:

--- a/Sources/CosmicSDK/CosmicEndpointProvider.swift
+++ b/Sources/CosmicSDK/CosmicEndpointProvider.swift
@@ -85,16 +85,16 @@ public struct CosmicEndpointProvider {
         }
     }
     
-    public func getPath(api: API, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String?, props: String? = nil, limit: String? = nil, status: Status? = nil, sort: Sorting? = nil, depth: Int? = nil, metadata: [String: AnyCodable]? = nil) -> (String, [String: String?]) {
+    public func getPath(api: API, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String?, props: String? = nil, limit: String? = nil, status: Status? = nil, sort: Sorting? = nil, metadata: [String: AnyCodable]? = nil) -> (String, [String: String?]) {
         switch source {
         case .cosmic:
             switch api {
             // Object endpoints
             case .find:
-                return ("/v3/buckets/\(bucket)/objects", ["read_key": read_key, "type": type, "limit": limit, "props": props, "status": status?.rawValue, "sort": sort?.rawValue, "depth": depth?.description])
+                return ("/v3/buckets/\(bucket)/objects", ["read_key": read_key, "type": type, "limit": limit, "props": props, "status": status?.rawValue, "sort": sort?.rawValue])
             case .findOne:
                 guard let id = id else { fatalError("Missing ID for \(api) operation") }
-                return ("/v3/buckets/\(bucket)/objects/\(id)", ["read_key": read_key, "props": props, "status": status?.rawValue, "depth": depth?.description])
+                return ("/v3/buckets/\(bucket)/objects/\(id)", ["read_key": read_key, "props": props, "status": status?.rawValue])
             case .insertOne:
                 return ("/v3/buckets/\(bucket)/objects", ["write_key": write_key])
             case .updateOne:

--- a/Sources/CosmicSDK/CosmicEndpointProvider.swift
+++ b/Sources/CosmicSDK/CosmicEndpointProvider.swift
@@ -85,16 +85,16 @@ public struct CosmicEndpointProvider {
         }
     }
     
-    public func getPath(api: API, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String?, props: String? = nil, limit: String? = nil, status: Status? = nil, sort: Sorting? = nil, metadata: [String: AnyCodable]? = nil) -> (String, [String: String?]) {
+    public func getPath(api: API, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String?, props: String? = nil, limit: String? = nil, status: Status? = nil, sort: Sorting? = nil, depth: Int? = nil, metadata: [String: AnyCodable]? = nil) -> (String, [String: String?]) {
         switch source {
         case .cosmic:
             switch api {
             // Object endpoints
             case .find:
-                return ("/v3/buckets/\(bucket)/objects", ["read_key": read_key, "type": type, "limit": limit, "props": props, "status": status?.rawValue, "sort": sort?.rawValue])
+                return ("/v3/buckets/\(bucket)/objects", ["read_key": read_key, "type": type, "limit": limit, "props": props, "status": status?.rawValue, "sort": sort?.rawValue, "depth": depth?.description])
             case .findOne:
                 guard let id = id else { fatalError("Missing ID for \(api) operation") }
-                return ("/v3/buckets/\(bucket)/objects/\(id)", ["read_key": read_key, "props": props, "status": status?.rawValue])
+                return ("/v3/buckets/\(bucket)/objects/\(id)", ["read_key": read_key, "props": props, "status": status?.rawValue, "depth": depth?.description])
             case .insertOne:
                 return ("/v3/buckets/\(bucket)/objects", ["write_key": write_key])
             case .updateOne:

--- a/Sources/CosmicSDK/CosmicEndpointProvider.swift
+++ b/Sources/CosmicSDK/CosmicEndpointProvider.swift
@@ -85,16 +85,16 @@ public struct CosmicEndpointProvider {
         }
     }
     
-    public func getPath(api: API, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String?, props: String? = nil, limit: String? = nil, status: Status? = nil, sort: Sorting? = nil, metadata: [String: AnyCodable]? = nil) -> (String, [String: String?]) {
+    public func getPath(api: API, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String?, props: String? = nil, limit: String? = nil, status: Status? = nil, sort: Sorting? = nil, depth: String? = nil, metadata: [String: AnyCodable]? = nil) -> (String, [String: String?]) {
         switch source {
         case .cosmic:
             switch api {
             // Object endpoints
             case .find:
-                return ("/v3/buckets/\(bucket)/objects", ["read_key": read_key, "type": type, "limit": limit, "props": props, "status": status?.rawValue, "sort": sort?.rawValue])
+                return ("/v3/buckets/\(bucket)/objects", ["read_key": read_key, "type": type, "limit": limit, "props": props, "status": status?.rawValue, "sort": sort?.rawValue, "depth": depth])
             case .findOne:
                 guard let id = id else { fatalError("Missing ID for \(api) operation") }
-                return ("/v3/buckets/\(bucket)/objects/\(id)", ["read_key": read_key, "props": props, "status": status?.rawValue])
+                return ("/v3/buckets/\(bucket)/objects/\(id)", ["read_key": read_key, "props": props, "status": status?.rawValue, "depth": depth])
             case .insertOne:
                 return ("/v3/buckets/\(bucket)/objects", ["write_key": write_key])
             case .updateOne:

--- a/Sources/CosmicSDK/CosmicEndpointProvider.swift
+++ b/Sources/CosmicSDK/CosmicEndpointProvider.swift
@@ -85,7 +85,7 @@ public struct CosmicEndpointProvider {
         }
     }
     
-    public func getPath(api: API, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String?, props: String? = nil, limit: String? = nil, status: Status? = nil, sort: Sorting? = nil, depth: String? = nil, metadata: [String: AnyCodable]? = nil) -> (String, [String: String?]) {
+    public func getPath(api: API, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String?, props: String? = nil, limit: String? = nil, skip: String? = nil, status: Status? = nil, sort: Sorting? = nil, depth: String? = nil, metadata: [String: AnyCodable]? = nil) -> (String, [String: String?]) {
         switch source {
         case .cosmic:
             switch api {
@@ -99,7 +99,7 @@ public struct CosmicEndpointProvider {
                 return ("/v3/buckets/\(bucket)/objects", [
                     "query": queryParam,
                     "limit": limit ?? "10",
-                    "skip": "0",
+                    "skip": skip ?? "0",
                     "props": finalProps,
                     "status": status?.rawValue,
                     "sort": sort?.rawValue,

--- a/Sources/CosmicSDK/CosmicSDK.swift
+++ b/Sources/CosmicSDK/CosmicSDK.swift
@@ -65,12 +65,9 @@ public class CosmicSDKSwift {
                   writeKey: writeKey,
                   session: .shared,
                   authorizeRequest: { request in
-                    // Use readKey for GET requests, writeKey for others
-                    if request.httpMethod == "GET" {
-                        // For GET requests, use readKey in Authorization header
-                        request.setValue("Bearer \(readKey)", forHTTPHeaderField: "Authorization")
-                    } else {
-                        // For other requests, use writeKey
+                    // Only add Authorization header for non-GET requests
+                    // GET requests use read_key in URL parameters
+                    if request.httpMethod != "GET" {
                         request.setValue("Bearer \(writeKey)", forHTTPHeaderField: "Authorization")
                     }
             })

--- a/Sources/CosmicSDK/CosmicSDK.swift
+++ b/Sources/CosmicSDK/CosmicSDK.swift
@@ -87,8 +87,8 @@ public class CosmicSDKSwift {
         task.resume()
     }
    
-    private func prepareRequest<BodyType>(_ endpoint: CosmicEndpointProvider.API, body: BodyType? = nil, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String? = nil, props: String? = nil, limit: String? = nil, title: String? = nil, slug: String? = nil, content: String? = nil, metadata: [String: AnyCodable]? = nil, sort: CosmicEndpointProvider.Sorting? = nil, status: CosmicEndpointProvider.Status? = nil) -> URLRequest where BodyType: Encodable {
-        let pathAndParameters = config.endpointProvider.getPath(api: endpoint, id: id, bucket: config.bucketSlug, type: type, read_key: config.readKey, write_key: config.writeKey, props: props, limit: limit, status: status, sort: sort)
+    private func prepareRequest<BodyType>(_ endpoint: CosmicEndpointProvider.API, body: BodyType? = nil, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String? = nil, props: String? = nil, limit: String? = nil, title: String? = nil, slug: String? = nil, content: String? = nil, metadata: [String: AnyCodable]? = nil, sort: CosmicEndpointProvider.Sorting? = nil, status: CosmicEndpointProvider.Status? = nil, depth: Int? = nil) -> URLRequest where BodyType: Encodable {
+        let pathAndParameters = config.endpointProvider.getPath(api: endpoint, id: id, bucket: config.bucketSlug, type: type, read_key: config.readKey, write_key: config.writeKey, props: props, limit: limit, status: status, sort: sort, depth: depth)
         
         // Create URL components based on whether we have a full URL or just a path
         let urlComponents: URLComponents
@@ -122,8 +122,8 @@ public class CosmicSDKSwift {
     }
 
     // Helper method for requests without body
-    private func prepareRequest(_ endpoint: CosmicEndpointProvider.API, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String? = nil, props: String? = nil, limit: String? = nil, title: String? = nil, slug: String? = nil, content: String? = nil, metadata: [String: AnyCodable]? = nil, sort: CosmicEndpointProvider.Sorting? = nil, status: CosmicEndpointProvider.Status? = nil) -> URLRequest {
-        return prepareRequest(endpoint, body: nil as String?, id: id, bucket: bucket, type: type, read_key: read_key, write_key: write_key, props: props, limit: limit, title: title, slug: slug, content: content, metadata: metadata, sort: sort, status: status)
+    private func prepareRequest(_ endpoint: CosmicEndpointProvider.API, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String? = nil, props: String? = nil, limit: String? = nil, title: String? = nil, slug: String? = nil, content: String? = nil, metadata: [String: AnyCodable]? = nil, sort: CosmicEndpointProvider.Sorting? = nil, status: CosmicEndpointProvider.Status? = nil, depth: Int? = nil) -> URLRequest {
+        return prepareRequest(endpoint, body: nil as String?, id: id, bucket: bucket, type: type, read_key: read_key, write_key: write_key, props: props, limit: limit, title: title, slug: slug, content: content, metadata: metadata, sort: sort, status: status, depth: depth)
     }
 
     private func mimeType(for url: URL) -> String {
@@ -171,9 +171,9 @@ extension CosmicSDKSwift {
         public let message: String?
     }
     
-    public func find(type: String, props: String? = nil, limit: Int? = nil, sort: CosmicSorting? = nil, status: CosmicStatus? = nil, completionHandler: @escaping (Result<CosmicSDK, CosmicError>) -> Void) {
+    public func find(type: String, props: String? = nil, limit: Int? = nil, sort: CosmicSorting? = nil, status: CosmicStatus? = nil, depth: Int? = nil, completionHandler: @escaping (Result<CosmicSDK, CosmicError>) -> Void) {
         let endpoint = CosmicEndpointProvider.API.find
-        let request = prepareRequest(endpoint, bucket: config.bucketSlug, type: type, read_key: config.readKey, limit: limit?.description, sort: sort, status: status)
+        let request = prepareRequest(endpoint, bucket: config.bucketSlug, type: type, read_key: config.readKey, props: props, limit: limit?.description, sort: sort, status: status, depth: depth)
         
         makeRequest(request: request) { result in
             switch result {
@@ -192,9 +192,9 @@ extension CosmicSDKSwift {
     
 
     
-    public func findOne(type: String, id: String, props: String? = nil, limit: Int? = nil, status: CosmicStatus? = nil, completionHandler: @escaping (Result<CosmicSDKSingle, CosmicError>) -> Void) {
+    public func findOne(type: String, id: String, props: String? = nil, limit: Int? = nil, status: CosmicStatus? = nil, depth: Int? = nil, completionHandler: @escaping (Result<CosmicSDKSingle, CosmicError>) -> Void) {
         let endpoint = CosmicEndpointProvider.API.findOne
-        let request = prepareRequest(endpoint, id: id, bucket: config.bucketSlug, type: type, read_key: config.readKey, status: status)
+        let request = prepareRequest(endpoint, id: id, bucket: config.bucketSlug, type: type, read_key: config.readKey, props: props, status: status, depth: depth)
                 
         makeRequest(request: request) { result in
             switch result {
@@ -466,9 +466,9 @@ extension CosmicSDKSwift {
 
 // MARK: - Object Operations (Async/Await)
 extension CosmicSDKSwift {
-    public func find(type: String, props: String? = nil, limit: Int? = nil, sort: CosmicSorting? = nil, status: CosmicStatus? = nil) async throws -> CosmicSDK {
+    public func find(type: String, props: String? = nil, limit: Int? = nil, sort: CosmicSorting? = nil, status: CosmicStatus? = nil, depth: Int? = nil) async throws -> CosmicSDK {
         let endpoint = CosmicEndpointProvider.API.find
-        let request = prepareRequest(endpoint, bucket: config.bucketSlug, type: type, read_key: config.readKey, limit: limit?.description, sort: sort, status: status)
+        let request = prepareRequest(endpoint, bucket: config.bucketSlug, type: type, read_key: config.readKey, props: props, limit: limit?.description, sort: sort, status: status, depth: depth)
         
         return try await withCheckedThrowingContinuation { continuation in
             makeRequest(request: request) { result in
@@ -487,9 +487,9 @@ extension CosmicSDKSwift {
         }
     }
     
-    public func findOne(type: String, id: String, props: String? = nil, limit: Int? = nil, status: CosmicStatus? = nil) async throws -> CosmicSDKSingle {
+    public func findOne(type: String, id: String, props: String? = nil, limit: Int? = nil, status: CosmicStatus? = nil, depth: Int? = nil) async throws -> CosmicSDKSingle {
         let endpoint = CosmicEndpointProvider.API.findOne
-        let request = prepareRequest(endpoint, id: id, bucket: config.bucketSlug, type: type, read_key: config.readKey, status: status)
+        let request = prepareRequest(endpoint, id: id, bucket: config.bucketSlug, type: type, read_key: config.readKey, props: props, status: status, depth: depth)
         
         return try await withCheckedThrowingContinuation { continuation in
             makeRequest(request: request) { result in

--- a/Sources/CosmicSDK/CosmicSDK.swift
+++ b/Sources/CosmicSDK/CosmicSDK.swift
@@ -103,8 +103,8 @@ public class CosmicSDKSwift {
         task.resume()
     }
    
-    private func prepareRequest<BodyType>(_ endpoint: CosmicEndpointProvider.API, body: BodyType? = nil, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String? = nil, props: String? = nil, limit: String? = nil, title: String? = nil, slug: String? = nil, content: String? = nil, metadata: [String: AnyCodable]? = nil, sort: CosmicEndpointProvider.Sorting? = nil, status: CosmicEndpointProvider.Status? = nil, depth: String? = nil) -> URLRequest where BodyType: Encodable {
-        let pathAndParameters = config.endpointProvider.getPath(api: endpoint, id: id, bucket: config.bucketSlug, type: type, read_key: config.readKey, write_key: config.writeKey, props: props, limit: limit, status: status, sort: sort, depth: depth)
+    private func prepareRequest<BodyType>(_ endpoint: CosmicEndpointProvider.API, body: BodyType? = nil, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String? = nil, props: String? = nil, limit: String? = nil, skip: String? = nil, title: String? = nil, slug: String? = nil, content: String? = nil, metadata: [String: AnyCodable]? = nil, sort: CosmicEndpointProvider.Sorting? = nil, status: CosmicEndpointProvider.Status? = nil, depth: String? = nil) -> URLRequest where BodyType: Encodable {
+        let pathAndParameters = config.endpointProvider.getPath(api: endpoint, id: id, bucket: config.bucketSlug, type: type, read_key: config.readKey, write_key: config.writeKey, props: props, limit: limit, skip: skip, status: status, sort: sort, depth: depth)
         
         // Create URL components based on whether we have a full URL or just a path
         let urlComponents: URLComponents
@@ -149,8 +149,8 @@ public class CosmicSDKSwift {
     }
 
     // Helper method for requests without body
-    private func prepareRequest(_ endpoint: CosmicEndpointProvider.API, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String? = nil, props: String? = nil, limit: String? = nil, title: String? = nil, slug: String? = nil, content: String? = nil, metadata: [String: AnyCodable]? = nil, sort: CosmicEndpointProvider.Sorting? = nil, status: CosmicEndpointProvider.Status? = nil, depth: String? = nil) -> URLRequest {
-        return prepareRequest(endpoint, body: nil as String?, id: id, bucket: bucket, type: type, read_key: read_key, write_key: write_key, props: props, limit: limit, title: title, slug: slug, content: content, metadata: metadata, sort: sort, status: status, depth: depth)
+    private func prepareRequest(_ endpoint: CosmicEndpointProvider.API, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String? = nil, props: String? = nil, limit: String? = nil, skip: String? = nil, title: String? = nil, slug: String? = nil, content: String? = nil, metadata: [String: AnyCodable]? = nil, sort: CosmicEndpointProvider.Sorting? = nil, status: CosmicEndpointProvider.Status? = nil, depth: String? = nil) -> URLRequest {
+        return prepareRequest(endpoint, body: nil as String?, id: id, bucket: bucket, type: type, read_key: read_key, write_key: write_key, props: props, limit: limit, skip: skip, title: title, slug: slug, content: content, metadata: metadata, sort: sort, status: status, depth: depth)
     }
 
     private func mimeType(for url: URL) -> String {
@@ -237,9 +237,9 @@ extension CosmicSDKSwift {
         }
     }
     
-    public func find(type: String, props: String? = nil, limit: Int? = nil, sort: CosmicSorting? = nil, status: CosmicStatus? = nil, depth: Int? = 1, completionHandler: @escaping (Result<CosmicSDK, CosmicError>) -> Void) {
+    public func find(type: String, props: String? = nil, limit: Int? = nil, skip: Int? = nil, sort: CosmicSorting? = nil, status: CosmicStatus? = nil, depth: Int? = 1, completionHandler: @escaping (Result<CosmicSDK, CosmicError>) -> Void) {
         let endpoint = CosmicEndpointProvider.API.find
-        let request = prepareRequest(endpoint, bucket: config.bucketSlug, type: type, read_key: config.readKey, props: props, limit: limit?.description, sort: sort, status: status, depth: depth?.description)
+        let request = prepareRequest(endpoint, bucket: config.bucketSlug, type: type, read_key: config.readKey, props: props, limit: limit?.description, skip: skip?.description, sort: sort, status: status, depth: depth?.description)
         
         makeRequest(request: request) { result in
             switch result {
@@ -576,9 +576,9 @@ extension CosmicSDKSwift {
 
 // MARK: - Object Operations (Async/Await)
 extension CosmicSDKSwift {
-    public func find(type: String, props: String? = nil, limit: Int? = nil, sort: CosmicSorting? = nil, status: CosmicStatus? = nil, depth: Int? = 1) async throws -> CosmicSDK {
+    public func find(type: String, props: String? = nil, limit: Int? = nil, skip: Int? = nil, sort: CosmicSorting? = nil, status: CosmicStatus? = nil, depth: Int? = 1) async throws -> CosmicSDK {
         let endpoint = CosmicEndpointProvider.API.find
-        let request = prepareRequest(endpoint, bucket: config.bucketSlug, type: type, read_key: config.readKey, props: props, limit: limit?.description, sort: sort, status: status, depth: depth?.description)
+        let request = prepareRequest(endpoint, bucket: config.bucketSlug, type: type, read_key: config.readKey, props: props, limit: limit?.description, skip: skip?.description, sort: sort, status: status, depth: depth?.description)
         
         return try await withCheckedThrowingContinuation { continuation in
             makeRequest(request: request) { result in

--- a/Sources/CosmicSDK/CosmicSDK.swift
+++ b/Sources/CosmicSDK/CosmicSDK.swift
@@ -87,8 +87,8 @@ public class CosmicSDKSwift {
         task.resume()
     }
    
-    private func prepareRequest<BodyType>(_ endpoint: CosmicEndpointProvider.API, body: BodyType? = nil, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String? = nil, props: String? = nil, limit: String? = nil, title: String? = nil, slug: String? = nil, content: String? = nil, metadata: [String: AnyCodable]? = nil, sort: CosmicEndpointProvider.Sorting? = nil, status: CosmicEndpointProvider.Status? = nil) -> URLRequest where BodyType: Encodable {
-        let pathAndParameters = config.endpointProvider.getPath(api: endpoint, id: id, bucket: config.bucketSlug, type: type, read_key: config.readKey, write_key: config.writeKey, props: props, limit: limit, status: status, sort: sort)
+    private func prepareRequest<BodyType>(_ endpoint: CosmicEndpointProvider.API, body: BodyType? = nil, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String? = nil, props: String? = nil, limit: String? = nil, title: String? = nil, slug: String? = nil, content: String? = nil, metadata: [String: AnyCodable]? = nil, sort: CosmicEndpointProvider.Sorting? = nil, status: CosmicEndpointProvider.Status? = nil, depth: String? = nil) -> URLRequest where BodyType: Encodable {
+        let pathAndParameters = config.endpointProvider.getPath(api: endpoint, id: id, bucket: config.bucketSlug, type: type, read_key: config.readKey, write_key: config.writeKey, props: props, limit: limit, status: status, sort: sort, depth: depth)
         
         // Create URL components based on whether we have a full URL or just a path
         let urlComponents: URLComponents
@@ -122,8 +122,8 @@ public class CosmicSDKSwift {
     }
 
     // Helper method for requests without body
-    private func prepareRequest(_ endpoint: CosmicEndpointProvider.API, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String? = nil, props: String? = nil, limit: String? = nil, title: String? = nil, slug: String? = nil, content: String? = nil, metadata: [String: AnyCodable]? = nil, sort: CosmicEndpointProvider.Sorting? = nil, status: CosmicEndpointProvider.Status? = nil) -> URLRequest {
-        return prepareRequest(endpoint, body: nil as String?, id: id, bucket: bucket, type: type, read_key: read_key, write_key: write_key, props: props, limit: limit, title: title, slug: slug, content: content, metadata: metadata, sort: sort, status: status)
+    private func prepareRequest(_ endpoint: CosmicEndpointProvider.API, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String? = nil, props: String? = nil, limit: String? = nil, title: String? = nil, slug: String? = nil, content: String? = nil, metadata: [String: AnyCodable]? = nil, sort: CosmicEndpointProvider.Sorting? = nil, status: CosmicEndpointProvider.Status? = nil, depth: String? = nil) -> URLRequest {
+        return prepareRequest(endpoint, body: nil as String?, id: id, bucket: bucket, type: type, read_key: read_key, write_key: write_key, props: props, limit: limit, title: title, slug: slug, content: content, metadata: metadata, sort: sort, status: status, depth: depth)
     }
 
     private func mimeType(for url: URL) -> String {
@@ -171,9 +171,9 @@ extension CosmicSDKSwift {
         public let message: String?
     }
     
-    public func find(type: String, props: String? = nil, limit: Int? = nil, sort: CosmicSorting? = nil, status: CosmicStatus? = nil, completionHandler: @escaping (Result<CosmicSDK, CosmicError>) -> Void) {
+    public func find(type: String, props: String? = nil, limit: Int? = nil, sort: CosmicSorting? = nil, status: CosmicStatus? = nil, depth: Int? = 1, completionHandler: @escaping (Result<CosmicSDK, CosmicError>) -> Void) {
         let endpoint = CosmicEndpointProvider.API.find
-        let request = prepareRequest(endpoint, bucket: config.bucketSlug, type: type, read_key: config.readKey, limit: limit?.description, sort: sort, status: status)
+        let request = prepareRequest(endpoint, bucket: config.bucketSlug, type: type, read_key: config.readKey, props: props, limit: limit?.description, sort: sort, status: status, depth: depth?.description)
         
         makeRequest(request: request) { result in
             switch result {
@@ -192,9 +192,9 @@ extension CosmicSDKSwift {
     
 
     
-    public func findOne(type: String, id: String, props: String? = nil, limit: Int? = nil, status: CosmicStatus? = nil, completionHandler: @escaping (Result<CosmicSDKSingle, CosmicError>) -> Void) {
+    public func findOne(type: String, id: String, props: String? = nil, limit: Int? = nil, status: CosmicStatus? = nil, depth: Int? = 1, completionHandler: @escaping (Result<CosmicSDKSingle, CosmicError>) -> Void) {
         let endpoint = CosmicEndpointProvider.API.findOne
-        let request = prepareRequest(endpoint, id: id, bucket: config.bucketSlug, type: type, read_key: config.readKey, status: status)
+        let request = prepareRequest(endpoint, id: id, bucket: config.bucketSlug, type: type, read_key: config.readKey, props: props, status: status, depth: depth?.description)
                 
         makeRequest(request: request) { result in
             switch result {
@@ -466,9 +466,9 @@ extension CosmicSDKSwift {
 
 // MARK: - Object Operations (Async/Await)
 extension CosmicSDKSwift {
-    public func find(type: String, props: String? = nil, limit: Int? = nil, sort: CosmicSorting? = nil, status: CosmicStatus? = nil) async throws -> CosmicSDK {
+    public func find(type: String, props: String? = nil, limit: Int? = nil, sort: CosmicSorting? = nil, status: CosmicStatus? = nil, depth: Int? = 1) async throws -> CosmicSDK {
         let endpoint = CosmicEndpointProvider.API.find
-        let request = prepareRequest(endpoint, bucket: config.bucketSlug, type: type, read_key: config.readKey, limit: limit?.description, sort: sort, status: status)
+        let request = prepareRequest(endpoint, bucket: config.bucketSlug, type: type, read_key: config.readKey, props: props, limit: limit?.description, sort: sort, status: status, depth: depth?.description)
         
         return try await withCheckedThrowingContinuation { continuation in
             makeRequest(request: request) { result in
@@ -487,9 +487,9 @@ extension CosmicSDKSwift {
         }
     }
     
-    public func findOne(type: String, id: String, props: String? = nil, limit: Int? = nil, status: CosmicStatus? = nil) async throws -> CosmicSDKSingle {
+    public func findOne(type: String, id: String, props: String? = nil, limit: Int? = nil, status: CosmicStatus? = nil, depth: Int? = 1) async throws -> CosmicSDKSingle {
         let endpoint = CosmicEndpointProvider.API.findOne
-        let request = prepareRequest(endpoint, id: id, bucket: config.bucketSlug, type: type, read_key: config.readKey, status: status)
+        let request = prepareRequest(endpoint, id: id, bucket: config.bucketSlug, type: type, read_key: config.readKey, props: props, status: status, depth: depth?.description)
         
         return try await withCheckedThrowingContinuation { continuation in
             makeRequest(request: request) { result in

--- a/Sources/CosmicSDK/CosmicSDK.swift
+++ b/Sources/CosmicSDK/CosmicSDK.swift
@@ -87,8 +87,8 @@ public class CosmicSDKSwift {
         task.resume()
     }
    
-    private func prepareRequest<BodyType>(_ endpoint: CosmicEndpointProvider.API, body: BodyType? = nil, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String? = nil, props: String? = nil, limit: String? = nil, title: String? = nil, slug: String? = nil, content: String? = nil, metadata: [String: AnyCodable]? = nil, sort: CosmicEndpointProvider.Sorting? = nil, status: CosmicEndpointProvider.Status? = nil, depth: Int? = nil) -> URLRequest where BodyType: Encodable {
-        let pathAndParameters = config.endpointProvider.getPath(api: endpoint, id: id, bucket: config.bucketSlug, type: type, read_key: config.readKey, write_key: config.writeKey, props: props, limit: limit, status: status, sort: sort, depth: depth)
+    private func prepareRequest<BodyType>(_ endpoint: CosmicEndpointProvider.API, body: BodyType? = nil, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String? = nil, props: String? = nil, limit: String? = nil, title: String? = nil, slug: String? = nil, content: String? = nil, metadata: [String: AnyCodable]? = nil, sort: CosmicEndpointProvider.Sorting? = nil, status: CosmicEndpointProvider.Status? = nil) -> URLRequest where BodyType: Encodable {
+        let pathAndParameters = config.endpointProvider.getPath(api: endpoint, id: id, bucket: config.bucketSlug, type: type, read_key: config.readKey, write_key: config.writeKey, props: props, limit: limit, status: status, sort: sort)
         
         // Create URL components based on whether we have a full URL or just a path
         let urlComponents: URLComponents
@@ -122,8 +122,8 @@ public class CosmicSDKSwift {
     }
 
     // Helper method for requests without body
-    private func prepareRequest(_ endpoint: CosmicEndpointProvider.API, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String? = nil, props: String? = nil, limit: String? = nil, title: String? = nil, slug: String? = nil, content: String? = nil, metadata: [String: AnyCodable]? = nil, sort: CosmicEndpointProvider.Sorting? = nil, status: CosmicEndpointProvider.Status? = nil, depth: Int? = nil) -> URLRequest {
-        return prepareRequest(endpoint, body: nil as String?, id: id, bucket: bucket, type: type, read_key: read_key, write_key: write_key, props: props, limit: limit, title: title, slug: slug, content: content, metadata: metadata, sort: sort, status: status, depth: depth)
+    private func prepareRequest(_ endpoint: CosmicEndpointProvider.API, id: String? = nil, bucket: String, type: String, read_key: String, write_key: String? = nil, props: String? = nil, limit: String? = nil, title: String? = nil, slug: String? = nil, content: String? = nil, metadata: [String: AnyCodable]? = nil, sort: CosmicEndpointProvider.Sorting? = nil, status: CosmicEndpointProvider.Status? = nil) -> URLRequest {
+        return prepareRequest(endpoint, body: nil as String?, id: id, bucket: bucket, type: type, read_key: read_key, write_key: write_key, props: props, limit: limit, title: title, slug: slug, content: content, metadata: metadata, sort: sort, status: status)
     }
 
     private func mimeType(for url: URL) -> String {
@@ -171,9 +171,9 @@ extension CosmicSDKSwift {
         public let message: String?
     }
     
-    public func find(type: String, props: String? = nil, limit: Int? = nil, sort: CosmicSorting? = nil, status: CosmicStatus? = nil, depth: Int? = nil, completionHandler: @escaping (Result<CosmicSDK, CosmicError>) -> Void) {
+    public func find(type: String, props: String? = nil, limit: Int? = nil, sort: CosmicSorting? = nil, status: CosmicStatus? = nil, completionHandler: @escaping (Result<CosmicSDK, CosmicError>) -> Void) {
         let endpoint = CosmicEndpointProvider.API.find
-        let request = prepareRequest(endpoint, bucket: config.bucketSlug, type: type, read_key: config.readKey, props: props, limit: limit?.description, sort: sort, status: status, depth: depth)
+        let request = prepareRequest(endpoint, bucket: config.bucketSlug, type: type, read_key: config.readKey, limit: limit?.description, sort: sort, status: status)
         
         makeRequest(request: request) { result in
             switch result {
@@ -192,9 +192,9 @@ extension CosmicSDKSwift {
     
 
     
-    public func findOne(type: String, id: String, props: String? = nil, limit: Int? = nil, status: CosmicStatus? = nil, depth: Int? = nil, completionHandler: @escaping (Result<CosmicSDKSingle, CosmicError>) -> Void) {
+    public func findOne(type: String, id: String, props: String? = nil, limit: Int? = nil, status: CosmicStatus? = nil, completionHandler: @escaping (Result<CosmicSDKSingle, CosmicError>) -> Void) {
         let endpoint = CosmicEndpointProvider.API.findOne
-        let request = prepareRequest(endpoint, id: id, bucket: config.bucketSlug, type: type, read_key: config.readKey, props: props, status: status, depth: depth)
+        let request = prepareRequest(endpoint, id: id, bucket: config.bucketSlug, type: type, read_key: config.readKey, status: status)
                 
         makeRequest(request: request) { result in
             switch result {
@@ -466,9 +466,9 @@ extension CosmicSDKSwift {
 
 // MARK: - Object Operations (Async/Await)
 extension CosmicSDKSwift {
-    public func find(type: String, props: String? = nil, limit: Int? = nil, sort: CosmicSorting? = nil, status: CosmicStatus? = nil, depth: Int? = nil) async throws -> CosmicSDK {
+    public func find(type: String, props: String? = nil, limit: Int? = nil, sort: CosmicSorting? = nil, status: CosmicStatus? = nil) async throws -> CosmicSDK {
         let endpoint = CosmicEndpointProvider.API.find
-        let request = prepareRequest(endpoint, bucket: config.bucketSlug, type: type, read_key: config.readKey, props: props, limit: limit?.description, sort: sort, status: status, depth: depth)
+        let request = prepareRequest(endpoint, bucket: config.bucketSlug, type: type, read_key: config.readKey, limit: limit?.description, sort: sort, status: status)
         
         return try await withCheckedThrowingContinuation { continuation in
             makeRequest(request: request) { result in
@@ -487,9 +487,9 @@ extension CosmicSDKSwift {
         }
     }
     
-    public func findOne(type: String, id: String, props: String? = nil, limit: Int? = nil, status: CosmicStatus? = nil, depth: Int? = nil) async throws -> CosmicSDKSingle {
+    public func findOne(type: String, id: String, props: String? = nil, limit: Int? = nil, status: CosmicStatus? = nil) async throws -> CosmicSDKSingle {
         let endpoint = CosmicEndpointProvider.API.findOne
-        let request = prepareRequest(endpoint, id: id, bucket: config.bucketSlug, type: type, read_key: config.readKey, props: props, status: status, depth: depth)
+        let request = prepareRequest(endpoint, id: id, bucket: config.bucketSlug, type: type, read_key: config.readKey, status: status)
         
         return try await withCheckedThrowingContinuation { continuation in
             makeRequest(request: request) { result in

--- a/Tests/CosmicSDKTests/MetadataCleanAPITests.swift
+++ b/Tests/CosmicSDKTests/MetadataCleanAPITests.swift
@@ -1,0 +1,143 @@
+//
+//  MetadataCleanAPITests.swift
+//  
+//
+//  Created to demonstrate the cleanest metadata API usage
+//
+
+import XCTest
+@testable import CosmicSDK
+
+final class MetadataCleanAPITests: XCTestCase {
+    
+    func testDirectComparison() throws {
+        let json = """
+        {
+            "title": "Product",
+            "metadata": {
+                "name": "iPhone 15 Pro",
+                "price": 999.99,
+                "in_stock": true,
+                "quantity": 42
+            }
+        }
+        """
+        
+        let data = json.data(using: .utf8)!
+        let product = try JSONDecoder().decode(Object.self, from: data)
+        
+        // Direct comparisons - the cleanest possible API!
+        XCTAssertTrue(product.metadata?.name == "iPhone 15 Pro")
+        XCTAssertTrue(product.metadata?.price == 999.99)
+        XCTAssertTrue(product.metadata?.in_stock == true)
+        XCTAssertTrue(product.metadata?.quantity == 42)
+        
+        // Works in if statements
+        if product.metadata?.in_stock == true {
+            print("Product is in stock!")
+        }
+        
+        // Works in guard statements
+        guard product.metadata?.quantity == 42 else {
+            XCTFail("Quantity should be 42")
+            return
+        }
+    }
+    
+    func testConditionalUsage() throws {
+        let json = """
+        {
+            "title": "User",
+            "metadata": {
+                "username": "johndoe",
+                "premium": true,
+                "credits": 100
+            }
+        }
+        """
+        
+        let data = json.data(using: .utf8)!
+        let user = try JSONDecoder().decode(Object.self, from: data)
+        
+        // Clean conditional checks
+        if user.metadata?.premium == true {
+            // Premium user logic
+            XCTAssertTrue(true)
+        }
+        
+        // Numeric comparisons need explicit type access
+        if let credits = user.metadata?.credits.int, credits > 50 {
+            // User has enough credits
+            XCTAssertTrue(true)
+        }
+        
+        // String checks
+        if user.metadata?.username == "johndoe" {
+            // Correct user
+            XCTAssertTrue(true)
+        }
+    }
+    
+    func testNestedAccess() throws {
+        let json = """
+        {
+            "title": "Company",
+            "metadata": {
+                "name": "Acme Corp",
+                "address": {
+                    "street": "123 Main St",
+                    "city": "San Francisco",
+                    "zip": "94105"
+                },
+                "employees": 150
+            }
+        }
+        """
+        
+        let data = json.data(using: .utf8)!
+        let company = try JSONDecoder().decode(Object.self, from: data)
+        
+        // Direct nested access
+        XCTAssertEqual(company.metadata?.address.city, "San Francisco")
+        XCTAssertEqual(company.metadata?.address.zip, "94105")
+        
+        // Check existence
+        XCTAssertTrue(company.metadata?.address.exists ?? false)
+        XCTAssertFalse(company.metadata?.nonexistent.exists ?? true)
+    }
+    
+    func testVariableAssignment() throws {
+        let json = """
+        {
+            "title": "Event",
+            "metadata": {
+                "title": "SwiftUI Workshop",
+                "date": "2024-03-15",
+                "price": 299.0,
+                "is_online": true
+            }
+        }
+        """
+        
+        let data = json.data(using: .utf8)!
+        let event = try JSONDecoder().decode(Object.self, from: data)
+        
+        // When you need to store values, use typed accessors
+        let eventTitle: String? = event.metadata?.title.string
+        let eventDate: String? = event.metadata?.date.string
+        let eventPrice: Double? = event.metadata?.price.double
+        let isOnline: Bool? = event.metadata?.is_online.bool
+        
+        XCTAssertEqual(eventTitle, "SwiftUI Workshop")
+        XCTAssertEqual(eventDate, "2024-03-15")
+        XCTAssertEqual(eventPrice, 299.0)
+        XCTAssertEqual(isOnline, true)
+        
+        // Or use type inference with explicit property access
+        let title = event.metadata?.title.stringValue
+        let price = event.metadata?.price.doubleValue
+        
+        XCTAssertEqual(title, "SwiftUI Workshop")
+        XCTAssertEqual(price, 299.0)
+    }
+}

--- a/Tests/CosmicSDKTests/MetadataDecodingTests.swift
+++ b/Tests/CosmicSDKTests/MetadataDecodingTests.swift
@@ -30,8 +30,9 @@ final class MetadataDecodingTests: XCTestCase {
         
         XCTAssertEqual(object.title, "Test Object")
         XCTAssertNotNil(object.metadata)
-        XCTAssertEqual(object.metadata?.count, 1)
-        XCTAssertEqual(object.metadata?.first?.key, "test_field")
+        XCTAssertEqual(object.metafields?.count, 1)
+        XCTAssertEqual(object.metafields?.first?.key, "test_field")
+        XCTAssertEqual(object.metafieldValue(for: "test_field")?.value as? String, "Test Value")
     }
     
     func testDecodingWithMetafieldsProperty() throws {
@@ -54,8 +55,9 @@ final class MetadataDecodingTests: XCTestCase {
         
         XCTAssertEqual(object.title, "Test Object")
         XCTAssertNotNil(object.metadata)
-        XCTAssertEqual(object.metadata?.count, 1)
-        XCTAssertEqual(object.metadata?.first?.key, "test_field")
+        XCTAssertEqual(object.metafields?.count, 1)
+        XCTAssertEqual(object.metafields?.first?.key, "test_field")
+        XCTAssertEqual(object.metafieldValue(for: "test_field")?.value as? String, "Test Value")
     }
     
     func testEncodingUsesMetadataProperty() throws {

--- a/Tests/CosmicSDKTests/MetadataDictionaryTests.swift
+++ b/Tests/CosmicSDKTests/MetadataDictionaryTests.swift
@@ -1,0 +1,196 @@
+//
+//  MetadataDictionaryTests.swift
+//  
+//
+//  Created to test dictionary-based metadata format
+//
+
+import XCTest
+@testable import CosmicSDK
+
+final class MetadataDictionaryTests: XCTestCase {
+    
+    func testDecodingDictionaryMetadata() throws {
+        let json = """
+        {
+            "title": "Test Object",
+            "metadata": {
+                "name": "John Doe",
+                "username": "johndoe",
+                "age": 25,
+                "active": true,
+                "tags": ["swift", "ios", "development"],
+                "profile": {
+                    "bio": "Developer",
+                    "location": "San Francisco"
+                }
+            }
+        }
+        """
+        
+        let data = json.data(using: .utf8)!
+        let object = try JSONDecoder().decode(Object.self, from: data)
+        
+        XCTAssertEqual(object.title, "Test Object")
+        XCTAssertNotNil(object.metadata)
+        
+        // Test accessing values via value(for:) method
+        XCTAssertEqual(object.metafieldValue(for: "name")?.value as? String, "John Doe")
+        XCTAssertEqual(object.metafieldValue(for: "username")?.value as? String, "johndoe")
+        XCTAssertEqual(object.metafieldValue(for: "age")?.value as? Int, 25)
+        XCTAssertEqual(object.metafieldValue(for: "active")?.value as? Bool, true)
+        
+        // Test accessing array values
+        if let tags = object.metafieldValue(for: "tags")?.value as? [Any] {
+            XCTAssertEqual(tags.count, 3)
+            XCTAssertEqual(tags[0] as? String, "swift")
+        }
+        
+        // Test accessing nested object values
+        if let profile = object.metafieldValue(for: "profile")?.value as? [String: Any] {
+            XCTAssertEqual(profile["bio"] as? String, "Developer")
+            XCTAssertEqual(profile["location"] as? String, "San Francisco")
+        }
+    }
+    
+    func testDynamicMemberLookup() throws {
+        let json = """
+        {
+            "title": "Test Object",
+            "metadata": {
+                "name": "John Doe",
+                "email": "john@example.com",
+                "is_premium": true
+            }
+        }
+        """
+        
+        let data = json.data(using: .utf8)!
+        let object = try JSONDecoder().decode(Object.self, from: data)
+        
+        // Test dynamic member lookup on metadata - direct comparison!
+        XCTAssertEqual(object.metadata?.name, "John Doe")
+        XCTAssertEqual(object.metadata?.email, "john@example.com")
+        XCTAssertEqual(object.metadata?.is_premium, true)
+        
+        // Or if you need to store in variables
+        let name = object.metadata?.name.string
+        let email = object.metadata?.email.string
+        let isPremium = object.metadata?.is_premium.bool
+        
+        XCTAssertEqual(name, "John Doe")
+        XCTAssertEqual(email, "john@example.com")
+        XCTAssertEqual(isPremium, true)
+        
+        // Test accessing non-existent property
+        XCTAssertNil(object.metadata?.non_existent.string)
+        XCTAssertFalse(object.metadata?.non_existent.exists ?? true)
+    }
+    
+    func testBackwardCompatibilityWithArrayFormat() throws {
+        let json = """
+        {
+            "title": "Test Object",
+            "metadata": [
+                {
+                    "type": "text",
+                    "title": "Name",
+                    "key": "name",
+                    "value": "John Doe"
+                },
+                {
+                    "type": "text",
+                    "title": "Email",
+                    "key": "email",
+                    "value": "john@example.com"
+                }
+            ]
+        }
+        """
+        
+        let data = json.data(using: .utf8)!
+        let object = try JSONDecoder().decode(Object.self, from: data)
+        
+        // Should still work with array format
+        XCTAssertEqual(object.metafieldValue(for: "name")?.value as? String, "John Doe")
+        XCTAssertEqual(object.metafieldValue(for: "email")?.value as? String, "john@example.com")
+        
+        // Test accessing as array
+        let fields = object.metafields
+        XCTAssertNotNil(fields)
+        XCTAssertEqual(fields?.count, 2)
+        
+        // Test accessing as dictionary
+        let dict = object.metafieldsDict
+        XCTAssertNotNil(dict)
+        XCTAssertEqual(dict?.count, 2)
+    }
+    
+    func testMixedContentTypes() throws {
+        let json = """
+        {
+            "title": "Event Object",
+            "metadata": {
+                "event_name": "CosmicCon 2024",
+                "start_date": "2024-06-15",
+                "attendee_count": 500,
+                "is_virtual": false,
+                "venue": {
+                    "name": "Convention Center",
+                    "address": "123 Main St"
+                },
+                "speakers": ["Alice", "Bob", "Charlie"],
+                "ticket_prices": {
+                    "early_bird": 99.99,
+                    "regular": 149.99,
+                    "vip": 299.99
+                }
+            }
+        }
+        """
+        
+        let data = json.data(using: .utf8)!
+        let object = try JSONDecoder().decode(Object.self, from: data)
+        
+        // Test various types - clean and type-safe!
+        XCTAssertEqual(object.metadata?.event_name.string, "CosmicCon 2024")
+        XCTAssertEqual(object.metadata?.attendee_count.int, 500)
+        XCTAssertEqual(object.metadata?.is_virtual.bool, false)
+        
+        // Test nested objects and arrays
+        if let speakers = object.metadata?.speakers.array(of: String.self) {
+            XCTAssertEqual(speakers.count, 3)
+            XCTAssertEqual(speakers[0], "Alice")
+        }
+        
+        if let prices = object.metadata?.ticket_prices.dictionary(keyType: String.self, valueType: Any.self) {
+            XCTAssertEqual(prices["early_bird"] as? Double, 99.99)
+        }
+    }
+    
+    func testEncodingDictionaryMetadata() throws {
+        let json = """
+        {
+            "title": "Test Object",
+            "metadata": {
+                "name": "John Doe",
+                "active": true
+            }
+        }
+        """
+        
+        let data = json.data(using: .utf8)!
+        let object = try JSONDecoder().decode(Object.self, from: data)
+        
+        // Re-encode and verify structure is preserved
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        let encodedData = try encoder.encode(object)
+        let encodedString = String(data: encodedData, encoding: .utf8)!
+        
+        // Should contain metadata as a dictionary
+        XCTAssertTrue(encodedString.contains("\"metadata\" : {"))
+        XCTAssertTrue(encodedString.contains("\"name\" : \"John Doe\""))
+        XCTAssertTrue(encodedString.contains("\"active\" : true"))
+    }
+}

--- a/Tests/CosmicSDKTests/MetadataUsageExampleTests.swift
+++ b/Tests/CosmicSDKTests/MetadataUsageExampleTests.swift
@@ -1,0 +1,120 @@
+//
+//  MetadataUsageExampleTests.swift
+//  
+//
+//  Created to demonstrate the cleaner metadata API usage
+//
+
+import XCTest
+@testable import CosmicSDK
+
+final class MetadataUsageExampleTests: XCTestCase {
+    
+    func testCleanMetadataAccess() throws {
+        // Example of a typical Cosmic CMS response with dictionary metadata
+        let json = """
+        {
+            "title": "John Doe",
+            "type": "users",
+            "metadata": {
+                "name": "John Doe",
+                "email": "john@example.com",
+                "age": 30,
+                "is_premium": true,
+                "bio": "Software developer from San Francisco",
+                "skills": ["Swift", "TypeScript", "Python"],
+                "social": {
+                    "twitter": "@johndoe",
+                    "github": "johndoe"
+                }
+            }
+        }
+        """
+        
+        let data = json.data(using: .utf8)!
+        let user = try JSONDecoder().decode(Object.self, from: data)
+        
+        // Clean, direct access to metadata values - no casting needed!
+        let name = user.metadata?.name.string
+        let email = user.metadata?.email.string
+        let age = user.metadata?.age.int
+        let isPremium = user.metadata?.is_premium.bool
+        let bio = user.metadata?.bio.string
+        
+        XCTAssertEqual(name, "John Doe")
+        XCTAssertEqual(email, "john@example.com")
+        XCTAssertEqual(age, 30)
+        XCTAssertEqual(isPremium, true)
+        XCTAssertEqual(bio, "Software developer from San Francisco")
+        
+        // Accessing arrays - type-safe!
+        if let skills = user.metadata?.skills.array(of: String.self) {
+            XCTAssertEqual(skills.count, 3)
+            XCTAssertTrue(skills.contains("Swift"))
+        }
+        
+        // Accessing nested objects - clean API
+        if let social = user.metadata?.social.dictionary(keyType: String.self, valueType: Any.self) {
+            XCTAssertEqual(social["twitter"] as? String, "@johndoe")
+            XCTAssertEqual(social["github"] as? String, "johndoe")
+        }
+    }
+    
+    func testRealWorldExample() throws {
+        // Example: Event object from Cosmic CMS
+        let json = """
+        {
+            "title": "Swift Conference 2024",
+            "type": "events",
+            "metadata": {
+                "event_name": "Swift Conference 2024",
+                "tagline": "The future of Swift development",
+                "start_date": "2024-06-15T09:00:00Z",
+                "end_date": "2024-06-17T18:00:00Z",
+                "location": "San Francisco Convention Center",
+                "max_attendees": 1000,
+                "is_virtual_enabled": true,
+                "ticket_price": 299.99,
+                "speakers": [
+                    "Chris Lattner",
+                    "Ted Kremenek",
+                    "Holly Borla"
+                ],
+                "venue": {
+                    "name": "Moscone Center",
+                    "address": "747 Howard St, San Francisco, CA 94103",
+                    "capacity": 1500
+                }
+            }
+        }
+        """
+        
+        let data = json.data(using: .utf8)!
+        let event = try JSONDecoder().decode(Object.self, from: data)
+        
+        // Direct, type-safe access to all metadata fields
+        let eventName = event.metadata?.event_name.string
+        let startDate = event.metadata?.start_date.string
+        let isVirtual = event.metadata?.is_virtual_enabled.bool
+        let price = event.metadata?.ticket_price.double
+        
+        XCTAssertEqual(eventName, "Swift Conference 2024")
+        XCTAssertEqual(startDate, "2024-06-15T09:00:00Z")
+        XCTAssertEqual(isVirtual, true)
+        XCTAssertEqual(price, 299.99)
+        
+        // Working with arrays and nested objects - no casting!
+        if let speakers = event.metadata?.speakers.array(of: String.self) {
+            XCTAssertTrue(speakers.contains("Chris Lattner"))
+        }
+        
+        if let venue = event.metadata?.venue.dictionary(keyType: String.self, valueType: Any.self) {
+            XCTAssertEqual(venue["name"] as? String, "Moscone Center")
+            XCTAssertEqual(venue["capacity"] as? Int, 1500)
+        }
+        
+        // Check field existence
+        XCTAssertTrue(event.metadata?.event_name.exists ?? false)
+        XCTAssertFalse(event.metadata?.cancelled.exists ?? true)
+    }
+}

--- a/debug_connection.swift
+++ b/debug_connection.swift
@@ -1,0 +1,51 @@
+#!/usr/bin/env swift
+
+import Foundation
+
+// Simple script to test Cosmic API connection
+// Run with: swift debug_connection.swift
+
+// Replace these with your actual values
+let BUCKET_SLUG = "your-bucket-slug"
+let READ_KEY = "your-read-key"
+
+// Create a simple HTTP client
+func testCosmicAPI() {
+    let urlString = "https://api.cosmicjs.com/v3/buckets/\(BUCKET_SLUG)?read_key=\(READ_KEY)"
+    guard let url = URL(string: urlString) else {
+        print("Invalid URL")
+        return
+    }
+    
+    var request = URLRequest(url: url)
+    request.httpMethod = "GET"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    
+    let task = URLSession.shared.dataTask(with: request) { data, response, error in
+        if let error = error {
+            print("Error: \(error)")
+            return
+        }
+        
+        if let httpResponse = response as? HTTPURLResponse {
+            print("Status Code: \(httpResponse.statusCode)")
+            print("Headers: \(httpResponse.allHeaderFields)")
+        }
+        
+        if let data = data {
+            if let jsonString = String(data: data, encoding: .utf8) {
+                print("Response: \(jsonString)")
+            } else {
+                print("Could not decode response as UTF-8")
+            }
+        }
+    }
+    
+    task.resume()
+}
+
+print("Testing Cosmic API connection...")
+testCosmicAPI()
+
+// Keep the script running to see the response
+RunLoop.main.run(until: Date().addingTimeInterval(5))


### PR DESCRIPTION
This pull request makes several improvements to the CosmicSDK, focusing on enhancing request customization, debugging capabilities, and API usability. The main changes include expanded support for query parameters (such as `skip` and `depth`), improved handling of request and response details for debugging, and the addition of new utility methods for bucket information and connection testing.

**Request and Query Parameter Enhancements:**

* Added support for `skip` and `depth` query parameters in the `getPath` method and throughout the SDK, allowing for more granular pagination and control over nested data retrieval. Default values for some parameters (like `limit`, `skip`, and `props`) are now set when not provided. [[1]](diffhunk://#diff-d31e5da51b63673a2debb9adb410adeaa68495281aadcdfbf208f9b5ca4800cfL88-R119) [[2]](diffhunk://#diff-a80a07d6351da9b640346749f36cf0847026500bf92636793c28f82107ce442cR87-R107) [[3]](diffhunk://#diff-a80a07d6351da9b640346749f36cf0847026500bf92636793c28f82107ce442cL125-R153) [[4]](diffhunk://#diff-a80a07d6351da9b640346749f36cf0847026500bf92636793c28f82107ce442cL174-R242) [[5]](diffhunk://#diff-a80a07d6351da9b640346749f36cf0847026500bf92636793c28f82107ce442cL195-R263)
* Refactored the SDK to only include non-empty query parameters in requests, ensuring cleaner and more accurate API calls.

**Debugging and Request Handling Improvements:**

* Added detailed debug print statements for both requests (URL, method, headers) and responses (status, headers, preview of body) to facilitate easier troubleshooting during development. [[1]](diffhunk://#diff-a80a07d6351da9b640346749f36cf0847026500bf92636793c28f82107ce442cR87-R107) [[2]](diffhunk://#diff-a80a07d6351da9b640346749f36cf0847026500bf92636793c28f82107ce442cR137-R141)
* Updated the logic for adding the `Authorization` header: it is now only included for non-GET requests, aligning with API expectations.

**API Usability Improvements:**

* Introduced new utility methods: `getBucketInfo` to fetch bucket metadata and `testConnection` to verify API connectivity, improving the developer experience and SDK capabilities.
* Updated several endpoints to remove the `read_key` from query parameters where it is not required, simplifying requests for media, user, webhook, and bucket operations. [[1]](diffhunk://#diff-d31e5da51b63673a2debb9adb410adeaa68495281aadcdfbf208f9b5ca4800cfL111-R156) [[2]](diffhunk://#diff-d31e5da51b63673a2debb9adb410adeaa68495281aadcdfbf208f9b5ca4800cfL143-R165)

These changes collectively make the SDK more robust, flexible, and easier to use for developers integrating with the Cosmic API.